### PR TITLE
Update build.gradle to support new Gradle version

### DIFF
--- a/theme/build.gradle
+++ b/theme/build.gradle
@@ -13,7 +13,7 @@ android {
     }
     buildTypes {
         release {
-            runProguard false
+            minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
     }


### PR DESCRIPTION
Replaced deprecated "runProguard" with "minifyEnabled", fixing initial Gradle sync errors in newer Android Studio builds upon import
